### PR TITLE
Add GitHub Pages landing page and privacy policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,11 @@ FlowWrite is a Chrome browser extension that provides real-time, inline AI-power
 
 ![FlowWrite Logo](extension/icons/icon128.png)
 
-## Features
+## 🚀 Live Demo
+
+Visit our [FlowWrite Website](https://chirag127.github.io/FlowWrite-Browser-Extension-/) to learn more about the extension and see it in action.
+
+## ✨ Features
 
 -   **Real-time AI Suggestions**: Get intelligent writing suggestions as you type, triggered by a brief pause.
 -   **Seamless Integration**: Accept suggestions instantly with the 'Tab' key.
@@ -12,15 +16,15 @@ FlowWrite is a Chrome browser extension that provides real-time, inline AI-power
 -   **Privacy-Focused**: Your API key is stored securely in your browser and never on our servers.
 -   **Site-Specific Control**: Enable or disable FlowWrite on specific websites.
 
-## Getting Started
+## 🚀 Getting Started
 
-### Prerequisites
+### 📋 Prerequisites
 
 -   Google Chrome browser
 -   A Google Gemini API key (get one at [Google AI Studio](https://aistudio.google.com/app/apikey))
 -   For development: Node.js and npm
 
-### Installation for Users
+### 💻 Installation for Users
 
 1. Install the extension from the Chrome Web Store (link coming soon)
 2. Click on the FlowWrite icon in your browser toolbar
@@ -28,7 +32,7 @@ FlowWrite is a Chrome browser extension that provides real-time, inline AI-power
 4. Configure your preferences
 5. Start typing in any text field on the web!
 
-### Installation for Developers
+### 🛠️ Installation for Developers
 
 1. Clone the repository:
 
@@ -64,14 +68,14 @@ FlowWrite is a Chrome browser extension that provides real-time, inline AI-power
     npm run dev
     ```
 
-## Usage
+## 🔧 Usage
 
 1. Type in any text field on the web
 2. Pause briefly to see AI-powered suggestions
 3. Press 'Tab' to accept a suggestion or continue typing to ignore it
 4. Press 'Esc' to dismiss a suggestion
 
-## Configuration Options
+## ⚙️ Configuration Options
 
 -   **API Key**: Enter your Google Gemini API key
 -   **Enable/Disable**: Toggle FlowWrite on or off globally
@@ -79,7 +83,7 @@ FlowWrite is a Chrome browser extension that provides real-time, inline AI-power
 -   **Suggestion Delay**: Adjust how long to wait before showing suggestions (200ms-2000ms)
 -   **Presentation Style**: Choose how suggestions appear (inline, popup, or side panel)
 
-## Privacy
+## 🔒 Privacy
 
 FlowWrite takes your privacy seriously:
 
@@ -88,7 +92,7 @@ FlowWrite takes your privacy seriously:
 -   Your text is only sent to Google Gemini API for generating suggestions
 -   No user-identifiable data is collected
 
-## Development
+## 👨‍💻 Development
 
 ### Project Structure
 
@@ -121,6 +125,8 @@ FlowWrite-Browser-Extension/
 │   │   └── db.js               # Database configuration
 │   ├── package.json            # Backend dependencies
 │   └── README.md               # Backend documentation
+├── index.html                  # Landing page for GitHub Pages
+├── privacy-policy.html         # Privacy policy page for GitHub Pages
 ├── package.json                # Root package.json for development tools
 ├── generate-icons.js           # Script to generate PNG icons from SVG
 └── README.md                   # Project documentation
@@ -162,7 +168,7 @@ FlowWrite follows a client-server architecture:
 -   [MongoDB](https://www.mongodb.com/)
 -   [Sharp](https://sharp.pixelplumbing.com/) (for icon generation)
 
-## Contributing
+## 🙌 Contributing
 
 Contributions are welcome! Please feel free to submit a Pull Request.
 
@@ -172,11 +178,11 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 4. Push to the branch (`git push origin feature/amazing-feature`)
 5. Open a Pull Request
 
-## License
+## 🪪 License
 
 This project is licensed under the MIT License - see the LICENSE file for details.
 
-## Acknowledgments
+## 👏 Acknowledgments
 
 -   Inspired by GitHub Copilot
 -   Powered by Google Gemini AI

--- a/extension/index.html
+++ b/extension/index.html
@@ -1,0 +1,449 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>FlowWrite - AI Writing Assistant</title>
+    <link rel="icon" href="icons/icon16.png" type="image/png">
+    <style>
+        :root {
+            --primary-color: #3498db;
+            --primary-dark: #2980b9;
+            --secondary-color: #2ecc71;
+            --secondary-dark: #27ae60;
+            --bg-dark: #121212;
+            --bg-card: #1e1e1e;
+            --text-light: #f5f5f5;
+            --text-gray: #aaaaaa;
+            --spacing-sm: 0.5rem;
+            --spacing-md: 1rem;
+            --spacing-lg: 2rem;
+            --spacing-xl: 4rem;
+            --border-radius: 8px;
+            --transition: all 0.3s ease;
+            --shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+            --max-width: 1200px;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            background-color: var(--bg-dark);
+            color: var(--text-light);
+            line-height: 1.6;
+        }
+
+        a {
+            color: var(--primary-color);
+            text-decoration: none;
+            transition: var(--transition);
+        }
+
+        a:hover {
+            color: var(--primary-dark);
+        }
+
+        .container {
+            max-width: var(--max-width);
+            margin: 0 auto;
+            padding: 0 var(--spacing-md);
+        }
+
+        .btn {
+            display: inline-block;
+            padding: 0.8rem 1.5rem;
+            background-color: var(--primary-color);
+            color: white;
+            border: none;
+            border-radius: var(--border-radius);
+            cursor: pointer;
+            transition: var(--transition);
+            font-weight: 600;
+            text-align: center;
+        }
+
+        .btn:hover {
+            background-color: var(--primary-dark);
+            transform: translateY(-2px);
+            box-shadow: var(--shadow);
+        }
+
+        .btn-secondary {
+            background-color: var(--secondary-color);
+        }
+
+        .btn-secondary:hover {
+            background-color: var(--secondary-dark);
+        }
+
+        .btn-outline {
+            background-color: transparent;
+            border: 2px solid var(--primary-color);
+            color: var(--primary-color);
+        }
+
+        .btn-outline:hover {
+            background-color: var(--primary-color);
+            color: white;
+        }
+
+        /* Header */
+        header {
+            padding: var(--spacing-lg) 0;
+            text-align: center;
+            background-color: rgba(0, 0, 0, 0.2);
+            position: relative;
+            overflow: hidden;
+        }
+
+        .header-content {
+            position: relative;
+            z-index: 2;
+            padding: var(--spacing-xl) 0;
+        }
+
+        .logo {
+            width: 120px;
+            height: 120px;
+            margin-bottom: var(--spacing-md);
+            animation: pulse 2s infinite alternate;
+        }
+
+        @keyframes pulse {
+            from {
+                transform: scale(1);
+            }
+            to {
+                transform: scale(1.05);
+            }
+        }
+
+        .tagline {
+            font-size: 1.2rem;
+            color: var(--text-gray);
+            margin-bottom: var(--spacing-lg);
+        }
+
+        .header-buttons {
+            display: flex;
+            justify-content: center;
+            gap: var(--spacing-md);
+            flex-wrap: wrap;
+        }
+
+        /* Sections */
+        section {
+            padding: var(--spacing-xl) 0;
+            border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+        }
+
+        .section-title {
+            text-align: center;
+            margin-bottom: var(--spacing-lg);
+            position: relative;
+            padding-bottom: var(--spacing-sm);
+        }
+
+        .section-title::after {
+            content: '';
+            position: absolute;
+            bottom: 0;
+            left: 50%;
+            transform: translateX(-50%);
+            width: 50px;
+            height: 3px;
+            background-color: var(--primary-color);
+        }
+
+        /* About Section */
+        .about-content {
+            max-width: 800px;
+            margin: 0 auto;
+            text-align: center;
+        }
+
+        /* Features Section */
+        .features-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+            gap: var(--spacing-lg);
+            margin-top: var(--spacing-lg);
+        }
+
+        .feature-card {
+            background-color: var(--bg-card);
+            border-radius: var(--border-radius);
+            padding: var(--spacing-lg);
+            transition: var(--transition);
+            box-shadow: var(--shadow);
+        }
+
+        .feature-card:hover {
+            transform: translateY(-5px);
+            box-shadow: 0 10px 20px rgba(0, 0, 0, 0.2);
+        }
+
+        .feature-icon {
+            font-size: 2.5rem;
+            margin-bottom: var(--spacing-md);
+            color: var(--primary-color);
+        }
+
+        .feature-title {
+            margin-bottom: var(--spacing-sm);
+        }
+
+        /* Installation Section */
+        .installation-steps {
+            max-width: 800px;
+            margin: 0 auto;
+        }
+
+        .step {
+            margin-bottom: var(--spacing-md);
+            padding: var(--spacing-md);
+            background-color: var(--bg-card);
+            border-radius: var(--border-radius);
+            position: relative;
+        }
+
+        .step-number {
+            position: absolute;
+            top: -15px;
+            left: -15px;
+            width: 30px;
+            height: 30px;
+            background-color: var(--primary-color);
+            color: white;
+            border-radius: 50%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-weight: bold;
+        }
+
+        /* How to Use Section */
+        .usage-content {
+            max-width: 800px;
+            margin: 0 auto;
+        }
+
+        /* Tech Stack Section */
+        .tech-list {
+            display: flex;
+            flex-wrap: wrap;
+            justify-content: center;
+            gap: var(--spacing-md);
+            margin-top: var(--spacing-lg);
+        }
+
+        .tech-item {
+            background-color: var(--bg-card);
+            padding: var(--spacing-md);
+            border-radius: var(--border-radius);
+            min-width: 150px;
+            text-align: center;
+            transition: var(--transition);
+        }
+
+        .tech-item:hover {
+            transform: translateY(-5px);
+            box-shadow: var(--shadow);
+        }
+
+        /* Footer */
+        footer {
+            padding: var(--spacing-lg) 0;
+            text-align: center;
+            background-color: rgba(0, 0, 0, 0.2);
+        }
+
+        .footer-links {
+            display: flex;
+            justify-content: center;
+            gap: var(--spacing-md);
+            margin-top: var(--spacing-md);
+            flex-wrap: wrap;
+        }
+
+        /* Responsive */
+        @media (max-width: 768px) {
+            .header-buttons {
+                flex-direction: column;
+                align-items: center;
+            }
+
+            .features-grid {
+                grid-template-columns: 1fr;
+            }
+
+            .tech-list {
+                flex-direction: column;
+                align-items: center;
+            }
+
+            .tech-item {
+                width: 100%;
+                max-width: 300px;
+            }
+        }
+    </style>
+</head>
+<body>
+    <!-- Header -->
+    <header>
+        <div class="container">
+            <div class="header-content">
+                <img src="icons/icon128.png" alt="FlowWrite Logo" class="logo">
+                <h1>FlowWrite</h1>
+                <p class="tagline">Real-time AI writing suggestions as you type</p>
+                <div class="header-buttons">
+                    <a href="https://github.com/chirag127/FlowWrite-Browser-Extension-" class="btn" target="_blank">GitHub Repository</a>
+                    <a href="privacy-policy.html" class="btn btn-outline" target="_blank">Privacy Policy</a>
+                </div>
+            </div>
+        </div>
+    </header>
+
+    <!-- About Section -->
+    <section id="about">
+        <div class="container">
+            <h2 class="section-title">About FlowWrite</h2>
+            <div class="about-content">
+                <p>FlowWrite is a browser extension that provides real-time AI-powered writing suggestions as you type in web forms and text fields. Powered by Google's Gemini AI, FlowWrite helps you write more efficiently, overcome writer's block, and improve your writing quality.</p>
+                <p>Whether you're composing emails, writing social media posts, or filling out forms, FlowWrite is your intelligent writing assistant that works seamlessly across the web.</p>
+            </div>
+        </div>
+    </section>
+
+    <!-- Features Section -->
+    <section id="features">
+        <div class="container">
+            <h2 class="section-title">Key Features</h2>
+            <div class="features-grid">
+                <div class="feature-card">
+                    <div class="feature-icon">✨</div>
+                    <h3 class="feature-title">Real-time Suggestions</h3>
+                    <p>Get intelligent writing suggestions as you type, helping you complete sentences and formulate ideas faster.</p>
+                </div>
+                <div class="feature-card">
+                    <div class="feature-icon">🌐</div>
+                    <h3 class="feature-title">Works Everywhere</h3>
+                    <p>FlowWrite works in any text field across the web, including email clients, social media, and messaging platforms.</p>
+                </div>
+                <div class="feature-card">
+                    <div class="feature-icon">⚡</div>
+                    <h3 class="feature-title">Keyboard Shortcuts</h3>
+                    <p>Accept suggestions with Tab key and dismiss with Esc key for a seamless writing experience.</p>
+                </div>
+                <div class="feature-card">
+                    <div class="feature-icon">🔒</div>
+                    <h3 class="feature-title">Privacy-Focused</h3>
+                    <p>Your data is processed securely and never stored permanently. Your privacy is our priority.</p>
+                </div>
+                <div class="feature-card">
+                    <div class="feature-icon">🎨</div>
+                    <h3 class="feature-title">Multiple Display Modes</h3>
+                    <p>Choose between inline, popup, or side panel suggestion displays based on your preference.</p>
+                </div>
+                <div class="feature-card">
+                    <div class="feature-icon">⚙️</div>
+                    <h3 class="feature-title">Customizable</h3>
+                    <p>Adjust suggestion delay, disable on specific sites, and customize other settings to suit your workflow.</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Installation Section -->
+    <section id="installation">
+        <div class="container">
+            <h2 class="section-title">Installation Instructions</h2>
+            <div class="installation-steps">
+                <div class="step">
+                    <div class="step-number">1</div>
+                    <h3>Download the Extension</h3>
+                    <p>Clone or download the repository from <a href="https://github.com/chirag127/FlowWrite-Browser-Extension-" target="_blank">GitHub</a>.</p>
+                </div>
+                <div class="step">
+                    <div class="step-number">2</div>
+                    <h3>Open Chrome Extensions Page</h3>
+                    <p>Navigate to <code>chrome://extensions/</code> in your Chrome browser.</p>
+                </div>
+                <div class="step">
+                    <div class="step-number">3</div>
+                    <h3>Enable Developer Mode</h3>
+                    <p>Toggle on "Developer mode" in the top-right corner of the extensions page.</p>
+                </div>
+                <div class="step">
+                    <div class="step-number">4</div>
+                    <h3>Load Unpacked Extension</h3>
+                    <p>Click "Load unpacked" and select the "extension" folder from the downloaded repository.</p>
+                </div>
+                <div class="step">
+                    <div class="step-number">5</div>
+                    <h3>Configure API Key</h3>
+                    <p>Click on the FlowWrite extension icon, go to options, and enter your Google Gemini API key.</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- How to Use Section -->
+    <section id="usage">
+        <div class="container">
+            <h2 class="section-title">How to Use</h2>
+            <div class="usage-content">
+                <p>Using FlowWrite is simple and intuitive:</p>
+                <ol>
+                    <li><strong>Start typing</strong> in any text field on the web.</li>
+                    <li><strong>Wait briefly</strong> for the AI to generate a suggestion (customizable delay).</li>
+                    <li><strong>Press Tab</strong> to accept the suggestion or <strong>Esc</strong> to dismiss it.</li>
+                    <li><strong>Continue writing</strong> and FlowWrite will provide more suggestions as you type.</li>
+                </ol>
+                <p>You can customize FlowWrite's behavior through the options page, accessible by right-clicking the extension icon and selecting "Options".</p>
+            </div>
+        </div>
+    </section>
+
+    <!-- Tech Stack Section -->
+    <section id="tech">
+        <div class="container">
+            <h2 class="section-title">Technology Stack</h2>
+            <div class="tech-list">
+                <div class="tech-item">
+                    <h3>JavaScript</h3>
+                </div>
+                <div class="tech-item">
+                    <h3>Chrome Extension API</h3>
+                </div>
+                <div class="tech-item">
+                    <h3>Google Gemini AI</h3>
+                </div>
+                <div class="tech-item">
+                    <h3>Node.js Backend</h3>
+                </div>
+                <div class="tech-item">
+                    <h3>Express.js</h3>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Footer -->
+    <footer>
+        <div class="container">
+            <p>&copy; 2023 FlowWrite. All rights reserved.</p>
+            <div class="footer-links">
+                <a href="privacy-policy.html" target="_blank">Privacy Policy</a>
+                <a href="https://github.com/chirag127/FlowWrite-Browser-Extension-" target="_blank">GitHub Repository</a>
+            </div>
+        </div>
+    </footer>
+</body>
+</html>

--- a/extension/privacy-policy.html
+++ b/extension/privacy-policy.html
@@ -1,0 +1,285 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Privacy Policy - FlowWrite</title>
+    <link rel="icon" href="icons/icon16.png" type="image/png">
+    <style>
+        :root {
+            --primary-color: #3498db;
+            --primary-dark: #2980b9;
+            --secondary-color: #2ecc71;
+            --secondary-dark: #27ae60;
+            --bg-dark: #121212;
+            --bg-card: #1e1e1e;
+            --text-light: #f5f5f5;
+            --text-gray: #aaaaaa;
+            --spacing-sm: 0.5rem;
+            --spacing-md: 1rem;
+            --spacing-lg: 2rem;
+            --spacing-xl: 4rem;
+            --border-radius: 8px;
+            --transition: all 0.3s ease;
+            --shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+            --max-width: 900px;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            background-color: var(--bg-dark);
+            color: var(--text-light);
+            line-height: 1.6;
+        }
+
+        a {
+            color: var(--primary-color);
+            text-decoration: none;
+            transition: var(--transition);
+        }
+
+        a:hover {
+            color: var(--primary-dark);
+        }
+
+        .container {
+            max-width: var(--max-width);
+            margin: 0 auto;
+            padding: 0 var(--spacing-md);
+        }
+
+        .btn {
+            display: inline-block;
+            padding: 0.8rem 1.5rem;
+            background-color: var(--primary-color);
+            color: white;
+            border: none;
+            border-radius: var(--border-radius);
+            cursor: pointer;
+            transition: var(--transition);
+            font-weight: 600;
+            text-align: center;
+        }
+
+        .btn:hover {
+            background-color: var(--primary-dark);
+            transform: translateY(-2px);
+            box-shadow: var(--shadow);
+        }
+
+        /* Header */
+        header {
+            padding: var(--spacing-lg) 0;
+            text-align: center;
+            background-color: rgba(0, 0, 0, 0.2);
+            position: relative;
+            overflow: hidden;
+        }
+
+        .header-content {
+            position: relative;
+            z-index: 2;
+            padding: var(--spacing-lg) 0;
+        }
+
+        .back-button {
+            position: absolute;
+            top: var(--spacing-lg);
+            left: var(--spacing-lg);
+            display: flex;
+            align-items: center;
+            gap: var(--spacing-sm);
+            color: var(--text-light);
+            font-weight: 600;
+        }
+
+        .back-button:hover {
+            color: var(--primary-color);
+        }
+
+        /* Content */
+        .content {
+            padding: var(--spacing-xl) 0;
+        }
+
+        .policy-section {
+            margin-bottom: var(--spacing-xl);
+        }
+
+        .policy-section h2 {
+            margin-bottom: var(--spacing-md);
+            color: var(--primary-color);
+            border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+            padding-bottom: var(--spacing-sm);
+        }
+
+        .policy-section p, .policy-section ul {
+            margin-bottom: var(--spacing-md);
+        }
+
+        .policy-section ul {
+            padding-left: var(--spacing-lg);
+        }
+
+        .policy-section li {
+            margin-bottom: var(--spacing-sm);
+        }
+
+        .highlight {
+            background-color: rgba(46, 204, 113, 0.2);
+            padding: 2px 5px;
+            border-radius: 3px;
+        }
+
+        .warning {
+            background-color: rgba(231, 76, 60, 0.2);
+            padding: 2px 5px;
+            border-radius: 3px;
+        }
+
+        .last-updated {
+            font-style: italic;
+            color: var(--text-gray);
+            margin-bottom: var(--spacing-lg);
+        }
+
+        /* Footer */
+        footer {
+            padding: var(--spacing-lg) 0;
+            text-align: center;
+            background-color: rgba(0, 0, 0, 0.2);
+            margin-top: var(--spacing-xl);
+        }
+
+        /* Responsive */
+        @media (max-width: 768px) {
+            .back-button {
+                position: relative;
+                top: 0;
+                left: 0;
+                justify-content: center;
+                margin-bottom: var(--spacing-md);
+            }
+        }
+    </style>
+</head>
+<body>
+    <!-- Header -->
+    <header>
+        <div class="container">
+            <a href="index.html" class="back-button">
+                ← Back to Home
+            </a>
+            <div class="header-content">
+                <h1>Privacy Policy</h1>
+                <p class="last-updated">Last Updated: June 15, 2023</p>
+            </div>
+        </div>
+    </header>
+
+    <!-- Content -->
+    <div class="content">
+        <div class="container">
+            <div class="policy-section">
+                <h2>Introduction</h2>
+                <p>This Privacy Policy explains how FlowWrite ("we", "our", or "us") collects, uses, and protects your information when you use our browser extension. We are committed to ensuring that your privacy is protected and that you understand how your data is used.</p>
+                <p>By using FlowWrite, you agree to the collection and use of information in accordance with this policy. We will not use or share your information with anyone except as described in this Privacy Policy.</p>
+            </div>
+
+            <div class="policy-section">
+                <h2>Required Permissions</h2>
+                <p>FlowWrite requires the following permissions to function properly:</p>
+                <ul>
+                    <li><strong>storage</strong> - This permission is required to save your preferences and settings, such as your API key, enabled/disabled status, and site-specific settings.</li>
+                    <li><strong>activeTab</strong> - This permission allows FlowWrite to interact with the content of the webpage you are currently viewing, specifically to detect text fields and provide suggestions.</li>
+                    <li><strong>scripting</strong> - This permission enables FlowWrite to inject scripts into web pages to detect text fields and provide suggestions as you type.</li>
+                    <li><strong>host permissions</strong> (https://*/*, http://*/*) - These permissions allow FlowWrite to work on all websites. This is necessary because FlowWrite needs to provide suggestions in text fields across the web.</li>
+                </ul>
+            </div>
+
+            <div class="policy-section">
+                <h2>Information We Collect</h2>
+                <p>FlowWrite collects the following information:</p>
+                <ul>
+                    <li><strong>User Preferences</strong> - We store your extension settings locally on your device, including your API key, enabled/disabled status, suggestion delay, presentation mode, and list of disabled sites.</li>
+                    <li><strong>Text Context</strong> - When you type in a text field, FlowWrite temporarily processes the text you've entered to generate appropriate suggestions. This text is sent to our backend server and then to the Google Gemini API.</li>
+                    <li><strong>Basic Usage Data</strong> - We collect anonymous usage data, such as whether suggestions were accepted or rejected, to improve the extension's functionality.</li>
+                </ul>
+                <p><span class="highlight">We DO NOT collect or store:</span></p>
+                <ul>
+                    <li>Your personal information (name, email, etc.)</li>
+                    <li>Your browsing history</li>
+                    <li>Your login credentials</li>
+                    <li>Any sensitive information you type</li>
+                </ul>
+            </div>
+
+            <div class="policy-section">
+                <h2>How We Use Your Information</h2>
+                <p>The information we collect is used for the following purposes:</p>
+                <ul>
+                    <li>To provide and maintain the FlowWrite service</li>
+                    <li>To generate relevant writing suggestions</li>
+                    <li>To improve the extension based on usage patterns</li>
+                    <li>To customize the extension according to your preferences</li>
+                </ul>
+                <p><span class="highlight">We do not sell, trade, or otherwise transfer your information to third parties for marketing or advertising purposes.</span></p>
+            </div>
+
+            <div class="policy-section">
+                <h2>Data Storage & Security</h2>
+                <p>Your preferences and settings are stored locally on your device using Chrome's storage API. The text you type is temporarily processed on our backend server and the Google Gemini API to generate suggestions, but is not permanently stored.</p>
+                <p>We implement appropriate security measures to protect against unauthorized access, alteration, disclosure, or destruction of your information. However, no method of transmission over the Internet or electronic storage is 100% secure, and we cannot guarantee absolute security.</p>
+            </div>
+
+            <div class="policy-section">
+                <h2>Third-Party Services</h2>
+                <p>FlowWrite uses the following third-party services:</p>
+                <ul>
+                    <li><strong>Google Gemini API</strong> - We use Google's Gemini AI to generate writing suggestions. Your text context is sent to this service. Please refer to <a href="https://policies.google.com/privacy" target="_blank">Google's Privacy Policy</a> for more information on how they handle data.</li>
+                </ul>
+                <p>Your API key for Google Gemini is stored locally on your device and is used to authenticate requests to the Google Gemini API. We do not have access to your API key unless you explicitly share it with us for troubleshooting purposes.</p>
+            </div>
+
+            <div class="policy-section">
+                <h2>User Rights</h2>
+                <p>As a user of FlowWrite, you have the following rights:</p>
+                <ul>
+                    <li>The right to disable the extension at any time</li>
+                    <li>The right to disable the extension on specific websites</li>
+                    <li>The right to clear your stored preferences by resetting the extension</li>
+                    <li>The right to uninstall the extension, which will remove all locally stored data</li>
+                </ul>
+            </div>
+
+            <div class="policy-section">
+                <h2>Changes to This Privacy Policy</h2>
+                <p>We may update our Privacy Policy from time to time. We will notify you of any changes by posting the new Privacy Policy on this page and updating the "Last Updated" date.</p>
+                <p>You are advised to review this Privacy Policy periodically for any changes. Changes to this Privacy Policy are effective when they are posted on this page.</p>
+            </div>
+
+            <div class="policy-section">
+                <h2>Contact Information</h2>
+                <p>If you have any questions or concerns about this Privacy Policy or FlowWrite's data practices, please contact us by:</p>
+                <ul>
+                    <li>Opening an issue on our <a href="https://github.com/chirag127/FlowWrite-Browser-Extension-" target="_blank">GitHub repository</a></li>
+                </ul>
+            </div>
+        </div>
+    </div>
+
+    <!-- Footer -->
+    <footer>
+        <div class="container">
+            <p>&copy; 2023 FlowWrite. All rights reserved.</p>
+            <a href="index.html">Back to Home</a>
+        </div>
+    </footer>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,506 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>FlowWrite - AI Writing Assistant</title>
+    <link rel="icon" href="extension/icons/icon16.png" type="image/png">
+    <style>
+        :root {
+            --primary-color: #3498db;
+            --primary-dark: #2980b9;
+            --secondary-color: #2ecc71;
+            --secondary-dark: #27ae60;
+            --bg-dark: #121212;
+            --bg-card: #1e1e1e;
+            --text-light: #f5f5f5;
+            --text-gray: #aaaaaa;
+            --spacing-sm: 0.5rem;
+            --spacing-md: 1rem;
+            --spacing-lg: 2rem;
+            --spacing-xl: 4rem;
+            --border-radius: 8px;
+            --transition: all 0.3s ease;
+            --shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+            --max-width: 1200px;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            background-color: var(--bg-dark);
+            color: var(--text-light);
+            line-height: 1.6;
+        }
+
+        a {
+            color: var(--primary-color);
+            text-decoration: none;
+            transition: var(--transition);
+        }
+
+        a:hover {
+            color: var(--primary-dark);
+        }
+
+        .container {
+            max-width: var(--max-width);
+            margin: 0 auto;
+            padding: 0 var(--spacing-md);
+        }
+
+        .btn {
+            display: inline-block;
+            padding: 0.8rem 1.5rem;
+            background-color: var(--primary-color);
+            color: white;
+            border: none;
+            border-radius: var(--border-radius);
+            cursor: pointer;
+            transition: var(--transition);
+            font-weight: 600;
+            text-align: center;
+        }
+
+        .btn:hover {
+            background-color: var(--primary-dark);
+            transform: translateY(-2px);
+            box-shadow: var(--shadow);
+        }
+
+        .btn-outline {
+            background-color: transparent;
+            border: 2px solid var(--primary-color);
+            color: var(--primary-color);
+        }
+
+        .btn-outline:hover {
+            background-color: var(--primary-color);
+            color: white;
+        }
+
+        /* Header */
+        header {
+            padding: var(--spacing-xl) 0;
+            background-color: rgba(0, 0, 0, 0.3);
+            position: relative;
+            overflow: hidden;
+        }
+
+        header::before {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: radial-gradient(circle at top right, rgba(52, 152, 219, 0.2), transparent 70%),
+                        radial-gradient(circle at bottom left, rgba(46, 204, 113, 0.2), transparent 70%);
+            z-index: -1;
+        }
+
+        .header-content {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            text-align: center;
+            gap: var(--spacing-md);
+        }
+
+        .logo {
+            width: 120px;
+            height: 120px;
+            border-radius: 20px;
+            box-shadow: var(--shadow);
+            transition: var(--transition);
+        }
+
+        .logo:hover {
+            transform: scale(1.05);
+        }
+
+        h1 {
+            font-size: 3rem;
+            margin-bottom: var(--spacing-sm);
+            background: linear-gradient(to right, var(--primary-color), var(--secondary-color));
+            -webkit-background-clip: text;
+            background-clip: text;
+            color: transparent;
+        }
+
+        .tagline {
+            font-size: 1.2rem;
+            color: var(--text-gray);
+            margin-bottom: var(--spacing-md);
+        }
+
+        .header-buttons {
+            display: flex;
+            gap: var(--spacing-md);
+            margin-top: var(--spacing-md);
+        }
+
+        /* Sections */
+        section {
+            padding: var(--spacing-xl) 0;
+            border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+        }
+
+        .section-title {
+            font-size: 2rem;
+            margin-bottom: var(--spacing-lg);
+            text-align: center;
+            position: relative;
+            padding-bottom: var(--spacing-sm);
+        }
+
+        .section-title::after {
+            content: '';
+            position: absolute;
+            bottom: 0;
+            left: 50%;
+            transform: translateX(-50%);
+            width: 60px;
+            height: 3px;
+            background: linear-gradient(to right, var(--primary-color), var(--secondary-color));
+            border-radius: 3px;
+        }
+
+        /* About Section */
+        .about-content {
+            max-width: 800px;
+            margin: 0 auto;
+            text-align: center;
+        }
+
+        .about-content p {
+            margin-bottom: var(--spacing-md);
+        }
+
+        /* Features Section */
+        .features-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+            gap: var(--spacing-lg);
+            margin-top: var(--spacing-lg);
+        }
+
+        .feature-card {
+            background-color: var(--bg-card);
+            padding: var(--spacing-lg);
+            border-radius: var(--border-radius);
+            box-shadow: var(--shadow);
+            transition: var(--transition);
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            text-align: center;
+        }
+
+        .feature-card:hover {
+            transform: translateY(-5px);
+            box-shadow: 0 10px 20px rgba(0, 0, 0, 0.2);
+        }
+
+        .feature-icon {
+            font-size: 2.5rem;
+            margin-bottom: var(--spacing-md);
+        }
+
+        .feature-title {
+            font-size: 1.3rem;
+            margin-bottom: var(--spacing-sm);
+            color: var(--primary-color);
+        }
+
+        /* Installation Section */
+        .installation-steps {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+            gap: var(--spacing-lg);
+            margin-top: var(--spacing-lg);
+        }
+
+        .step {
+            background-color: var(--bg-card);
+            padding: var(--spacing-lg);
+            border-radius: var(--border-radius);
+            box-shadow: var(--shadow);
+            position: relative;
+            transition: var(--transition);
+        }
+
+        .step:hover {
+            transform: translateY(-5px);
+            box-shadow: 0 10px 20px rgba(0, 0, 0, 0.2);
+        }
+
+        .step-number {
+            position: absolute;
+            top: -15px;
+            left: -15px;
+            width: 40px;
+            height: 40px;
+            background: linear-gradient(to right, var(--primary-color), var(--secondary-color));
+            border-radius: 50%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-weight: bold;
+            font-size: 1.2rem;
+            color: white;
+            box-shadow: var(--shadow);
+        }
+
+        .step h3 {
+            margin-bottom: var(--spacing-sm);
+            color: var(--primary-color);
+        }
+
+        /* Usage Section */
+        .usage-content {
+            max-width: 800px;
+            margin: 0 auto;
+            background-color: var(--bg-card);
+            padding: var(--spacing-lg);
+            border-radius: var(--border-radius);
+            box-shadow: var(--shadow);
+        }
+
+        .usage-content ol {
+            margin: var(--spacing-md) 0;
+            padding-left: var(--spacing-lg);
+        }
+
+        .usage-content li {
+            margin-bottom: var(--spacing-sm);
+        }
+
+        /* Tech Stack Section */
+        .tech-list {
+            display: flex;
+            flex-wrap: wrap;
+            justify-content: center;
+            gap: var(--spacing-md);
+            margin-top: var(--spacing-lg);
+        }
+
+        .tech-item {
+            background-color: var(--bg-card);
+            padding: var(--spacing-md) var(--spacing-lg);
+            border-radius: var(--border-radius);
+            box-shadow: var(--shadow);
+            transition: var(--transition);
+        }
+
+        .tech-item:hover {
+            transform: translateY(-5px);
+            background-color: var(--primary-dark);
+        }
+
+        /* Footer */
+        footer {
+            padding: var(--spacing-lg) 0;
+            text-align: center;
+            background-color: rgba(0, 0, 0, 0.3);
+        }
+
+        .footer-links {
+            display: flex;
+            justify-content: center;
+            gap: var(--spacing-lg);
+            margin-top: var(--spacing-md);
+        }
+
+        /* Responsive */
+        @media (max-width: 768px) {
+            h1 {
+                font-size: 2.5rem;
+            }
+
+            .header-buttons {
+                flex-direction: column;
+                width: 100%;
+                max-width: 300px;
+            }
+
+            .features-grid,
+            .installation-steps {
+                grid-template-columns: 1fr;
+            }
+
+            .tech-list {
+                flex-direction: column;
+                align-items: center;
+            }
+        }
+
+        code {
+            background-color: rgba(0, 0, 0, 0.3);
+            padding: 0.2rem 0.4rem;
+            border-radius: 4px;
+            font-family: monospace;
+        }
+    </style>
+</head>
+<body>
+    <!-- Header -->
+    <header>
+        <div class="container">
+            <div class="header-content">
+                <img src="extension/icons/icon128.png" alt="FlowWrite Logo" class="logo">
+                <h1>FlowWrite</h1>
+                <p class="tagline">Real-time AI writing suggestions as you type</p>
+                <div class="header-buttons">
+                    <a href="https://github.com/chirag127/FlowWrite-Browser-Extension-" class="btn" target="_blank">GitHub Repository</a>
+                    <a href="privacy-policy.html" class="btn btn-outline" target="_blank">Privacy Policy</a>
+                </div>
+            </div>
+        </div>
+    </header>
+
+    <!-- About Section -->
+    <section id="about">
+        <div class="container">
+            <h2 class="section-title">About FlowWrite</h2>
+            <div class="about-content">
+                <p>FlowWrite is a browser extension that provides real-time AI-powered writing suggestions as you type in web forms and text fields. Powered by Google's Gemini AI, FlowWrite helps you write more efficiently, overcome writer's block, and improve your writing quality.</p>
+                <p>Whether you're composing emails, writing social media posts, or filling out forms, FlowWrite is your intelligent writing assistant that works seamlessly across the web.</p>
+            </div>
+        </div>
+    </section>
+
+    <!-- Features Section -->
+    <section id="features">
+        <div class="container">
+            <h2 class="section-title">Key Features</h2>
+            <div class="features-grid">
+                <div class="feature-card">
+                    <div class="feature-icon">✨</div>
+                    <h3 class="feature-title">Real-time Suggestions</h3>
+                    <p>Get intelligent writing suggestions as you type, helping you complete sentences and formulate ideas faster.</p>
+                </div>
+                <div class="feature-card">
+                    <div class="feature-icon">🌐</div>
+                    <h3 class="feature-title">Works Everywhere</h3>
+                    <p>FlowWrite works in any text field across the web, including email clients, social media, and messaging platforms.</p>
+                </div>
+                <div class="feature-card">
+                    <div class="feature-icon">⚡</div>
+                    <h3 class="feature-title">Keyboard Shortcuts</h3>
+                    <p>Accept suggestions with a simple Tab key press or dismiss them with Esc, keeping your workflow smooth and efficient.</p>
+                </div>
+                <div class="feature-card">
+                    <div class="feature-icon">🔒</div>
+                    <h3 class="feature-title">Privacy-Focused</h3>
+                    <p>Your API key is stored securely in your browser and never on our servers. Your data remains private.</p>
+                </div>
+                <div class="feature-card">
+                    <div class="feature-icon">⚙️</div>
+                    <h3 class="feature-title">Customizable</h3>
+                    <p>Configure suggestion delay, presentation style, and enable/disable FlowWrite on specific websites.</p>
+                </div>
+                <div class="feature-card">
+                    <div class="feature-icon">🧠</div>
+                    <h3 class="feature-title">Powered by Gemini AI</h3>
+                    <p>Leverage Google's advanced Gemini AI model for high-quality, context-aware writing suggestions.</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Installation Section -->
+    <section id="installation">
+        <div class="container">
+            <h2 class="section-title">Installation Instructions</h2>
+            <div class="installation-steps">
+                <div class="step">
+                    <div class="step-number">1</div>
+                    <h3>Download the Extension</h3>
+                    <p>Clone or download the repository from <a href="https://github.com/chirag127/FlowWrite-Browser-Extension-" target="_blank">GitHub</a>.</p>
+                </div>
+                <div class="step">
+                    <div class="step-number">2</div>
+                    <h3>Open Chrome Extensions Page</h3>
+                    <p>Navigate to <code>chrome://extensions/</code> in your Chrome browser.</p>
+                </div>
+                <div class="step">
+                    <div class="step-number">3</div>
+                    <h3>Enable Developer Mode</h3>
+                    <p>Toggle on "Developer mode" in the top-right corner of the extensions page.</p>
+                </div>
+                <div class="step">
+                    <div class="step-number">4</div>
+                    <h3>Load Unpacked Extension</h3>
+                    <p>Click "Load unpacked" and select the "extension" folder from the downloaded repository.</p>
+                </div>
+                <div class="step">
+                    <div class="step-number">5</div>
+                    <h3>Configure API Key</h3>
+                    <p>Click on the FlowWrite extension icon, go to options, and enter your Google Gemini API key from <a href="https://aistudio.google.com/app/apikey" target="_blank">Google AI Studio</a>.</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- How to Use Section -->
+    <section id="usage">
+        <div class="container">
+            <h2 class="section-title">How to Use</h2>
+            <div class="usage-content">
+                <p>Using FlowWrite is simple and intuitive:</p>
+                <ol>
+                    <li><strong>Start typing</strong> in any text field on the web.</li>
+                    <li><strong>Wait briefly</strong> for the AI to generate a suggestion (customizable delay).</li>
+                    <li><strong>Press Tab</strong> to accept the suggestion or <strong>Esc</strong> to dismiss it.</li>
+                    <li><strong>Continue writing</strong> and FlowWrite will provide more suggestions as you type.</li>
+                </ol>
+                <p>You can customize FlowWrite's behavior through the options page, accessible by right-clicking the extension icon and selecting "Options".</p>
+            </div>
+        </div>
+    </section>
+
+    <!-- Tech Stack Section -->
+    <section id="tech">
+        <div class="container">
+            <h2 class="section-title">Technology Stack</h2>
+            <div class="tech-list">
+                <div class="tech-item">
+                    <h3>JavaScript</h3>
+                </div>
+                <div class="tech-item">
+                    <h3>Chrome Extension API</h3>
+                </div>
+                <div class="tech-item">
+                    <h3>Google Gemini AI</h3>
+                </div>
+                <div class="tech-item">
+                    <h3>Node.js Backend</h3>
+                </div>
+                <div class="tech-item">
+                    <h3>Express.js</h3>
+                </div>
+                <div class="tech-item">
+                    <h3>MongoDB</h3>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Footer -->
+    <footer>
+        <div class="container">
+            <p>&copy; 2024 FlowWrite. All rights reserved.</p>
+            <div class="footer-links">
+                <a href="privacy-policy.html" target="_blank">Privacy Policy</a>
+                <a href="https://github.com/chirag127/FlowWrite-Browser-Extension-" target="_blank">GitHub Repository</a>
+            </div>
+        </div>
+    </footer>
+</body>
+</html>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -1,0 +1,313 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Privacy Policy - FlowWrite</title>
+    <link rel="icon" href="extension/icons/icon16.png" type="image/png">
+    <style>
+        :root {
+            --primary-color: #3498db;
+            --primary-dark: #2980b9;
+            --secondary-color: #2ecc71;
+            --secondary-dark: #27ae60;
+            --bg-dark: #121212;
+            --bg-card: #1e1e1e;
+            --text-light: #f5f5f5;
+            --text-gray: #aaaaaa;
+            --spacing-sm: 0.5rem;
+            --spacing-md: 1rem;
+            --spacing-lg: 2rem;
+            --spacing-xl: 4rem;
+            --border-radius: 8px;
+            --transition: all 0.3s ease;
+            --shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+            --max-width: 900px;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            background-color: var(--bg-dark);
+            color: var(--text-light);
+            line-height: 1.6;
+        }
+
+        a {
+            color: var(--primary-color);
+            text-decoration: none;
+            transition: var(--transition);
+        }
+
+        a:hover {
+            color: var(--primary-dark);
+        }
+
+        .container {
+            max-width: var(--max-width);
+            margin: 0 auto;
+            padding: 0 var(--spacing-md);
+        }
+
+        .btn {
+            display: inline-block;
+            padding: 0.8rem 1.5rem;
+            background-color: var(--primary-color);
+            color: white;
+            border: none;
+            border-radius: var(--border-radius);
+            cursor: pointer;
+            transition: var(--transition);
+            font-weight: 600;
+            text-align: center;
+        }
+
+        .btn:hover {
+            background-color: var(--primary-dark);
+            transform: translateY(-2px);
+            box-shadow: var(--shadow);
+        }
+
+        /* Header */
+        header {
+            padding: var(--spacing-xl) 0;
+            background-color: rgba(0, 0, 0, 0.3);
+            position: relative;
+            overflow: hidden;
+        }
+
+        header::before {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: radial-gradient(circle at top right, rgba(52, 152, 219, 0.2), transparent 70%),
+                        radial-gradient(circle at bottom left, rgba(46, 204, 113, 0.2), transparent 70%);
+            z-index: -1;
+        }
+
+        .header-content {
+            text-align: center;
+            position: relative;
+        }
+
+        .back-button {
+            display: flex;
+            align-items: center;
+            gap: var(--spacing-sm);
+            position: absolute;
+            top: 0;
+            left: 0;
+            padding: var(--spacing-sm) var(--spacing-md);
+            background-color: rgba(0, 0, 0, 0.3);
+            border-radius: var(--border-radius);
+            transition: var(--transition);
+        }
+
+        .back-button:hover {
+            background-color: rgba(0, 0, 0, 0.5);
+            transform: translateX(-3px);
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            margin-bottom: var(--spacing-sm);
+            background: linear-gradient(to right, var(--primary-color), var(--secondary-color));
+            -webkit-background-clip: text;
+            background-clip: text;
+            color: transparent;
+        }
+
+        .last-updated {
+            font-size: 0.9rem;
+            color: var(--text-gray);
+            margin-bottom: var(--spacing-md);
+        }
+
+        /* Content */
+        .content {
+            padding: var(--spacing-xl) 0;
+        }
+
+        .policy-section {
+            background-color: var(--bg-card);
+            padding: var(--spacing-lg);
+            border-radius: var(--border-radius);
+            margin-bottom: var(--spacing-lg);
+            box-shadow: var(--shadow);
+        }
+
+        .policy-section h2 {
+            color: var(--primary-color);
+            margin-bottom: var(--spacing-md);
+            padding-bottom: var(--spacing-sm);
+            border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+        }
+
+        .policy-section p {
+            margin-bottom: var(--spacing-md);
+        }
+
+        .policy-section ul, .policy-section ol {
+            margin: var(--spacing-md) 0;
+            padding-left: var(--spacing-lg);
+        }
+
+        .policy-section li {
+            margin-bottom: var(--spacing-sm);
+        }
+
+        .highlight {
+            background-color: rgba(46, 204, 113, 0.2);
+            padding: 0.2rem 0.4rem;
+            border-radius: 4px;
+            font-weight: bold;
+        }
+
+        /* Footer */
+        footer {
+            padding: var(--spacing-lg) 0;
+            text-align: center;
+            background-color: rgba(0, 0, 0, 0.3);
+        }
+
+        footer a {
+            margin-top: var(--spacing-sm);
+            display: inline-block;
+        }
+
+        /* Responsive */
+        @media (max-width: 768px) {
+            .back-button {
+                position: relative;
+                top: 0;
+                left: 0;
+                justify-content: center;
+                margin-bottom: var(--spacing-md);
+            }
+        }
+    </style>
+</head>
+<body>
+    <!-- Header -->
+    <header>
+        <div class="container">
+            <a href="index.html" class="back-button">
+                ← Back to Home
+            </a>
+            <div class="header-content">
+                <h1>Privacy Policy</h1>
+                <p class="last-updated">Last Updated: June 15, 2024</p>
+            </div>
+        </div>
+    </header>
+
+    <!-- Content -->
+    <div class="content">
+        <div class="container">
+            <div class="policy-section">
+                <h2>Introduction</h2>
+                <p>This Privacy Policy explains how FlowWrite ("we", "our", or "us") collects, uses, and protects your information when you use our browser extension. We are committed to ensuring that your privacy is protected and that you understand how your data is used.</p>
+                <p>By using FlowWrite, you agree to the collection and use of information in accordance with this policy. We will not use or share your information with anyone except as described in this Privacy Policy.</p>
+            </div>
+
+            <div class="policy-section">
+                <h2>Required Permissions</h2>
+                <p>FlowWrite requires the following permissions to function properly:</p>
+                <ul>
+                    <li><strong>storage</strong> - This permission is required to save your preferences and settings, such as your API key, enabled/disabled status, and site-specific settings.</li>
+                    <li><strong>activeTab</strong> - This permission allows FlowWrite to interact with the content of the webpage you are currently viewing, specifically to detect text fields and provide suggestions.</li>
+                    <li><strong>scripting</strong> - This permission enables FlowWrite to inject scripts into web pages to detect text fields and provide suggestions as you type.</li>
+                    <li><strong>host permissions</strong> - Access to web pages is necessary for the extension to function across different websites and provide suggestions in text fields.</li>
+                </ul>
+                <p>These permissions are essential for the core functionality of FlowWrite and are used only for the purposes described in this Privacy Policy.</p>
+            </div>
+
+            <div class="policy-section">
+                <h2>Information We Collect</h2>
+                <p>FlowWrite collects the following information:</p>
+                <ul>
+                    <li><strong>User Preferences</strong> - We store your extension settings locally on your device, including your API key, enabled/disabled status, suggestion delay, presentation mode, and list of disabled sites.</li>
+                    <li><strong>Text Context</strong> - When you type in a text field, FlowWrite temporarily processes the text you've entered to generate appropriate suggestions. This text is sent to our backend server and then to the Google Gemini API.</li>
+                    <li><strong>Basic Usage Data</strong> - We collect anonymous usage data, such as whether suggestions were accepted or rejected, to improve the extension's functionality.</li>
+                </ul>
+                <p><strong>What We Do NOT Collect:</strong></p>
+                <ul>
+                    <li>Personal identification information</li>
+                    <li>Your browsing history</li>
+                    <li>Information from websites you visit beyond what's necessary for generating suggestions</li>
+                    <li>Your Google Gemini API key is never stored on our servers</li>
+                </ul>
+            </div>
+
+            <div class="policy-section">
+                <h2>How We Use Your Information</h2>
+                <p>The information we collect is used for the following purposes:</p>
+                <ul>
+                    <li>To provide and maintain the FlowWrite service</li>
+                    <li>To generate relevant writing suggestions</li>
+                    <li>To improve the extension based on usage patterns</li>
+                    <li>To customize the extension according to your preferences</li>
+                </ul>
+                <p><span class="highlight">We do not sell, trade, or otherwise transfer your information to third parties for marketing or advertising purposes.</span></p>
+            </div>
+
+            <div class="policy-section">
+                <h2>Data Storage & Security</h2>
+                <p>Your preferences and settings are stored locally on your device using Chrome's storage API. The text you type is temporarily processed on our backend server and the Google Gemini API to generate suggestions, but is not permanently stored.</p>
+                <p>We implement appropriate security measures to protect against unauthorized access, alteration, disclosure, or destruction of your information. However, no method of transmission over the Internet or electronic storage is 100% secure, and we cannot guarantee absolute security.</p>
+                <p>Your API key is stored securely in your browser using <code>chrome.storage.local</code> and is only used to authenticate requests to the Google Gemini API. We do not have access to your API key unless you explicitly share it with us for troubleshooting purposes.</p>
+            </div>
+
+            <div class="policy-section">
+                <h2>Third-Party Services</h2>
+                <p>FlowWrite uses the following third-party services:</p>
+                <ul>
+                    <li><strong>Google Gemini API</strong> - We use Google's Gemini AI to generate writing suggestions. Your text context is sent to this service. Please refer to <a href="https://policies.google.com/privacy" target="_blank">Google's Privacy Policy</a> for more information on how they handle data.</li>
+                </ul>
+                <p>Your API key for Google Gemini is stored locally on your device and is used to authenticate requests to the Google Gemini API. We do not have access to your API key unless you explicitly share it with us for troubleshooting purposes.</p>
+            </div>
+
+            <div class="policy-section">
+                <h2>User Rights</h2>
+                <p>As a user of FlowWrite, you have the following rights:</p>
+                <ul>
+                    <li>The right to disable the extension at any time</li>
+                    <li>The right to disable the extension on specific websites</li>
+                    <li>The right to clear your stored preferences by resetting the extension</li>
+                    <li>The right to uninstall the extension, which will remove all locally stored data</li>
+                </ul>
+            </div>
+
+            <div class="policy-section">
+                <h2>Changes to This Privacy Policy</h2>
+                <p>We may update our Privacy Policy from time to time. We will notify you of any changes by posting the new Privacy Policy on this page and updating the "Last Updated" date.</p>
+                <p>You are advised to review this Privacy Policy periodically for any changes. Changes to this Privacy Policy are effective when they are posted on this page.</p>
+            </div>
+
+            <div class="policy-section">
+                <h2>Contact Information</h2>
+                <p>If you have any questions or concerns about this Privacy Policy or FlowWrite's data practices, please contact us by:</p>
+                <ul>
+                    <li>Opening an issue on our <a href="https://github.com/chirag127/FlowWrite-Browser-Extension-" target="_blank">GitHub repository</a></li>
+                </ul>
+            </div>
+        </div>
+    </div>
+
+    <!-- Footer -->
+    <footer>
+        <div class="container">
+            <p>&copy; 2024 FlowWrite. All rights reserved.</p>
+            <a href="index.html">Back to Home</a>
+        </div>
+    </footer>
+</body>
+</html>


### PR DESCRIPTION
This PR adds:

- A landing page (`index.html`) for the FlowWrite browser extension
- A privacy policy page (`privacy-policy.html`)
- Updates to the README.md to include a link to the GitHub Pages site

Both pages feature a responsive dark theme design with detailed information about the extension, its features, and privacy considerations.

After merging, please enable GitHub Pages in the repository settings to serve from the main branch.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

## Summary by Sourcery

Add a project website hosted on GitHub Pages, featuring a landing page and a privacy policy. Update the README to link to the new site.

New Features:
- Introduce a landing page describing the FlowWrite extension.
- Include a duplicate landing page within the `extension` directory.

Documentation:
- Add a detailed privacy policy page.
- Include a duplicate privacy policy page within the `extension` directory.
- Update the README with the website link and new file structure.